### PR TITLE
2151 Update vcpkg dependencies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "vcpkg"]
 	path = vcpkg
 	url = https://github.com/microsoft/vcpkg.git
-	branch = master
+	branch = bd7fc2c

--- a/arm64-osx-nes.cmake
+++ b/arm64-osx-nes.cmake
@@ -1,0 +1,29 @@
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+
+set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
+set(VCPKG_OSX_ARCHITECTURES arm64)
+
+
+if (PORT STREQUAL paho-mqtt)
+	set(VCPKG_LIBRARY_LINKAGE dynamic)
+endif()
+
+if (PORT STREQUAL eclipse-paho-mqtt-c)
+	set(VCPKG_LIBRARY_LINKAGE dynamic)
+endif()
+
+if (PORT STREQUAL paho-mqttpp3)
+	set(VCPKG_LIBRARY_LINKAGE dynamic)
+endif()
+
+
+if (PORT STREQUAL paho-mqttpp3)
+	set(VCPKG_LIBRARY_LINKAGE dynamic)
+endif()
+
+if (PORT STREQUAL llvm)
+	set(VCPKG_BUILD_TYPE release)
+endif()
+

--- a/build-linux-arm64.sh
+++ b/build-linux-arm64.sh
@@ -3,7 +3,7 @@
 #./vcpkg/bootstrap-vcpkg.sh
 export VCPKG_DEFAULT_TRIPLET="arm64-linux-nes"
 export VCPKG_DEFAULT_HOST_TRIPLET="$VCPKG_DEFAULT_TRIPLET"
-version="v3"
+version="v4"
 outputFileName="nes-dependencies-$version-$VCPKG_DEFAULT_TRIPLET"
 outputDir="."
 libs=(

--- a/build-linux-steffen.sh
+++ b/build-linux-steffen.sh
@@ -3,7 +3,7 @@
 #./vcpkg/bootstrap-vcpkg.sh
 export VCPKG_DEFAULT_TRIPLET="x64-linux-nes"
 export VCPKG_DEFAULT_HOST_TRIPLET="$VCPKG_DEFAULT_TRIPLET"
-version="v3"
+version="v4"
 outputFileName="nes-dependencies-$version-$VCPKG_DEFAULT_TRIPLET"
 outputDir="."
 postfix=""

--- a/build-linux-x64.sh
+++ b/build-linux-x64.sh
@@ -3,7 +3,7 @@
 #./vcpkg/bootstrap-vcpkg.sh
 export VCPKG_DEFAULT_TRIPLET="x64-linux-nes"
 export VCPKG_DEFAULT_HOST_TRIPLET="$VCPKG_DEFAULT_TRIPLET"
-version="v3"
+version="v4"
 outputFileName="nes-dependencies-$version-$VCPKG_DEFAULT_TRIPLET"
 outputDir="."
 postfix=""

--- a/build-linux-x64.sh
+++ b/build-linux-x64.sh
@@ -43,7 +43,8 @@ libs=(
 # kafka lib
 "cppkafka"
 # jemalloc is a general purpose malloc(3) implementation that emphasizes fragmentation avoidance and scalable concurrency support
-"jemalloc"
+# Disable jemalloc for now #2159
+#"jemalloc"
 # An open source, portable, easy to use, readable and flexible SSL library
 "mbedtls"
 # open62541 is an open source C (C99) implementation of OPC UA licensed under the Mozilla Public License v2.0.

--- a/build-osx-arm64.sh
+++ b/build-osx-arm64.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+#./vcpkg/bootstrap-vcpkg.sh
+export VCPKG_DEFAULT_TRIPLET="arm64-osx-nes"
+export VCPKG_DEFAULT_HOST_TRIPLET="$VCPKG_DEFAULT_TRIPLET"
+version="v4"
+outputFileName="nes-dependencies-$version-$VCPKG_DEFAULT_TRIPLET"
+outputDir="."
+libs=(
+# The LLVM Compiler Infrastructure.
+"llvm[core,clang,target-aarch64]"
+# # Z3 is a theorem prover from Microsoft Research.
+"z3"
+# # Boost
+"boost-system"
+"boost-process"
+"boost-thread"
+"boost-program-options"
+"boost-filesystem"
+"boost-chrono"
+# The ZeroMQ lightweight messaging kernel 
+"zeromq"
+# lightweight messaging kernel, C++ bindings
+"cppzmq"
+# Apache log4cxx is a logging framework
+"log4cxx"
+# An RPC library and framework
+"grpc"
+# An open-source C++ library developed and used at Facebook. 
+#"folly"
+# C++11 JSON, REST, and OAuth library The C++ REST SDK is a Microsoft
+"cpprestsdk"
+# An event notification library
+"libevent"
+# Formatting library for C++. It can be used as a safe alternative to printf or as a fast alternative to IOStreams.
+"fmt"
+# Paho project provides open-source client implementations of MQTT and MQTT-SN messaging protocols 
+"paho-mqtt"
+# # Paho project provides open-source C++ wrapper for Paho C library
+"paho-mqttpp3" 
+# # kafka lib
+# "cppkafka"
+# # jemalloc is a general purpose malloc(3) implementation that emphasizes fragmentation avoidance and scalable concurrency support
+#"jemalloc"
+# # An open source, portable, easy to use, readable and flexible SSL library
+"mbedtls"
+# # open62541 is an open source C (C99) implementation of OPC UA licensed under the Mozilla Public License v2.0.
+"open62541"
+# libsodium is necessary as 3rd-party library
+"libsodium"
+# template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms
+"eigen3"
+# add support to libcrypto
+"asio[openssl]"
+#add support to libiconv
+"libiconv"
+)
+     
+
+for i in "${libs[@]}"; do   # The quotes are necessary here
+    ./vcpkg/vcpkg install "$i" --host-triplet=$VCPKG_DEFAULT_TRIPLET --triplet=$VCPKG_DEFAULT_TRIPLET --overlay-triplets=./
+done
+
+exports=""
+for i in "${libs[@]}"; do   # The quotes are necessary here
+    exports="$exports $i$postfix"
+done
+
+echo $exports
+com="./vcpkg/vcpkg export $exports  --host-triplet=$VCPKG_DEFAULT_TRIPLET --triplet=$VCPKG_DEFAULT_TRIPLET --overlay-triplets=./ --7zip --output-dir=$outputDir --output=$outputFileName"
+echo "$com"
+eval $com

--- a/build-osx-x64.sh
+++ b/build-osx-x64.sh
@@ -3,7 +3,7 @@
 #./vcpkg/bootstrap-vcpkg.sh
 export VCPKG_DEFAULT_TRIPLET="x64-osx-nes"
 export VCPKG_DEFAULT_HOST_TRIPLET="$VCPKG_DEFAULT_TRIPLET"
-version="v3"
+version="v4"
 outputFileName="nes-dependencies-$version-$VCPKG_DEFAULT_TRIPLET"
 outputDir="."
 libs=(


### PR DESCRIPTION
## What is the purpose of the change

This PR updates the the dependencies to use https://github.com/microsoft/vcpkg/commit/bd7fc2c and adds a build script for macOS on Apple M1 Macs.

## Brief change log

- Bump dependencies version to https://github.com/microsoft/vcpkg/commit/bd7fc2c
- Update build script to create v4 7z files
- Create build script for macOS on Apple M1 Macs
- Disable jemalloc as workaround for #2159

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): Yes, LLVM to 12.0.0 and Boost to 1.76.0