### PR TITLE
[#2099] Bump version on main file

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nebulastream-dependencies",
-  "version-string": "v5",
+  "version-string": "v6",
   "homepage": "https://nebula.stream",
   "description": "Data Management for the Internet of Things.",
   "supports": "x64 & (linux | osx)",


### PR DESCRIPTION
This PR is a test to bump the main vcpkg.json file and update the version string.

This helps close #2099 in the main repository.